### PR TITLE
Update spacelift.theme

### DIFF
--- a/spacelift.theme
+++ b/spacelift.theme
@@ -32,7 +32,9 @@ function spacelift_preprocess_block(&$variables) {
   }
 
   $block_id = $variables['elements']['#id'];
-  $block = Block::load($block_id);
 
-  $variables['region'] = $block->getRegion();
+  if (isset($block_id)) {
+    $block = Block::load($block_id);
+    $variables['region'] = $block->getRegion();
+  }
 }


### PR DESCRIPTION
Blocks don't always have a region or an ID when they're rendered - for example, blocks rendered in a block field in display suite. This change will only load the block and set the region variable for blocks displayed in regions using block settings or context.